### PR TITLE
Allow path string updates

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,6 +1,10 @@
 name: Check & fix styling
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   php-cs-fixer:

--- a/src/Models/Traits/HasUploadFields.php
+++ b/src/Models/Traits/HasUploadFields.php
@@ -75,7 +75,6 @@ trait HasUploadFields
             // 3. Save the complete path to the database
             $this->attributes[$attribute_name] = $file_path;
         } else {
-
             // If the request did not include a file,
             $this->attributes[$attribute_name] = $value;
         }
@@ -155,7 +154,6 @@ trait HasUploadFields
      */
     public function uploadImage(string $value, string $attribute_name, string $disk, string $destination_path): void
     {
-
         // if the image was erased
         if (! $value) {
             // delete the image from disk

--- a/src/Models/Traits/HasUploadFields.php
+++ b/src/Models/Traits/HasUploadFields.php
@@ -36,10 +36,17 @@ trait HasUploadFields
      * @param string $disk Filesystem disk used to store files.
      * @param string $destination_path Path in disk where to store the files.
      */
-    public function uploadFileWithNames($value, $attribute_name, $disk, $destination_path)
+    public function uploadFileWithNames(string $value, string $attribute_name, string $disk, string $destination_path): void
     {
+        $request = request();
+
+        if(!$request) {
+            return;
+        }
+
+
         // if a new file is uploaded, delete the file from the disk
-        if (request()->hasFile($attribute_name) &&
+        if ($request->hasFile($attribute_name) &&
             $this->{$attribute_name} &&
             $this->{$attribute_name} != null) {
             Storage::disk($disk)->delete($this->{$attribute_name});
@@ -54,9 +61,9 @@ trait HasUploadFields
 
 
         // if a new file is uploaded, store it on disk and its filename in the database
-        if (request()->hasFile($attribute_name) && request()->file($attribute_name)->isValid()) {
+        if ($request->hasFile($attribute_name) && $request->file($attribute_name)->isValid()) {
             // 1. Generate a new file name
-            $file = request()->file($attribute_name);
+            $file = $request->file($attribute_name);
 
             $new_file_name = $file->getClientOriginalName() . time() . '.' . $file->getClientOriginalExtension();
 
@@ -89,14 +96,20 @@ trait HasUploadFields
      * @param string $disk Filesystem disk used to store files.
      * @param string $destination_path Path in disk where to store the files.
      */
-    public function uploadMultipleFilesWithNames($value, $attribute_name, $disk, $destination_path)
+    public function uploadMultipleFilesWithNames(string $value, string $attribute_name, string $disk, string $destination_path): void
     {
+        $request = request();
+
+        if(!$request) {
+            return;
+        }
+
         if (!is_array($this->{$attribute_name})) {
             $attribute_value = json_decode($this->{$attribute_name}, true) ?? [];
         } else {
             $attribute_value = $this->{$attribute_name};
         }
-        $files_to_clear = request()->get('clear_' . $attribute_name);
+        $files_to_clear = $request->get('clear_' . $attribute_name);
 
         // if a file has been marked for removal,
         // delete it from the disk and from the db
@@ -104,14 +117,14 @@ trait HasUploadFields
             foreach ($files_to_clear as $key => $filename) {
                 Storage::disk($disk)->delete($filename);
                 $attribute_value = Arr::where($attribute_value, function ($value, $key) use ($filename) {
-                    return $value != $filename;
+                    return $value !== $filename;
                 });
             }
         }
 
         // if a new file is uploaded, store it on disk and its filename in the database
-        if (request()->hasFile($attribute_name)) {
-            foreach (request()->file($attribute_name) as $file) {
+        if ($request->hasFile($attribute_name)) {
+            foreach ($request->file($attribute_name) as $file) {
                 if ($file->isValid()) {
                     // 1. Generate a new file name
                     $name = explode('.', $file->getClientOriginalName());
@@ -134,17 +147,17 @@ trait HasUploadFields
     /**
      * Function to handle the saving of an image uploaded as a base64-encoded string.
      *
-     * @param $value
-     * @param $attribute_name
-     * @param $disk
-     * @param $destination_path
+     * @param string $value
+     * @param string $attribute_name
+     * @param string $disk
+     * @param string $destination_path
      * @return void
      */
-    public function uploadImage($value, $attribute_name, $disk, $destination_path)
+    public function uploadImage(string $value, string $attribute_name, string $disk, string $destination_path): void
     {
 
         // if the image was erased
-        if ($value == null) {
+        if (!$value) {
             // delete the image from disk
             Storage::disk($disk)->delete($this->{$attribute_name});
 

--- a/src/Models/Traits/HasUploadFields.php
+++ b/src/Models/Traits/HasUploadFields.php
@@ -40,7 +40,7 @@ trait HasUploadFields
     {
         $request = request();
 
-        if(!$request) {
+        if (! $request) {
             return;
         }
 
@@ -100,7 +100,7 @@ trait HasUploadFields
     {
         $request = request();
 
-        if(!$request) {
+        if (! $request) {
             return;
         }
 
@@ -157,7 +157,7 @@ trait HasUploadFields
     {
 
         // if the image was erased
-        if (!$value) {
+        if (! $value) {
             // delete the image from disk
             Storage::disk($disk)->delete($this->{$attribute_name});
 

--- a/src/Models/Traits/HasUploadFields.php
+++ b/src/Models/Traits/HasUploadFields.php
@@ -104,7 +104,7 @@ trait HasUploadFields
             return;
         }
 
-        if (!is_array($this->{$attribute_name})) {
+        if (! is_array($this->{$attribute_name})) {
             $attribute_value = json_decode($this->{$attribute_name}, true) ?? [];
         } else {
             $attribute_value = $this->{$attribute_name};

--- a/src/Models/Traits/HasUploadFields.php
+++ b/src/Models/Traits/HasUploadFields.php
@@ -91,7 +91,7 @@ trait HasUploadFields
      */
     public function uploadMultipleFilesWithNames($value, $attribute_name, $disk, $destination_path)
     {
-        if (!is_array($this->{$attribute_name})) {
+        if (! is_array($this->{$attribute_name})) {
             $attribute_value = json_decode($this->{$attribute_name}, true) ?? [];
         } else {
             $attribute_value = $this->{$attribute_name};

--- a/src/Models/Traits/HasUploadFields.php
+++ b/src/Models/Traits/HasUploadFields.php
@@ -96,7 +96,7 @@ trait HasUploadFields
      * @param string $disk Filesystem disk used to store files.
      * @param string $destination_path Path in disk where to store the files.
      */
-    public function uploadMultipleFilesWithNames(string $value, string $attribute_name, string $disk, string $destination_path): void
+    public function uploadMultipleFilesWithNames(?array $value, string $attribute_name, string $disk, string $destination_path): void
     {
         $request = request();
 


### PR DESCRIPTION
Small PR to add fallback code:

- This only changes the `uploadFileWithNames` function. Now, when saving a value to a single-file field, if there is no accompanying file in the request, the given string wil still be saved to the database, with the assumption that it's the path to a file. 

**Why:**
 - For testing, we can now instantiate models that use this trait without needing to create a full request with a valid file.
 - in some situations, we may want to reference a file that already exists in the system instead of uploading a new one.


The other functions `uploadMultipleFilesWithName` and `uploadImage` are unchanged (The multi-file version could benefit from this, but it's more complicated given the data is stored as json, and honestly I think almost every time we might need this function in the future we will probably use the Spatie Media library components instead...)



