### PR TITLE
Laravel 9 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,4 +44,4 @@ jobs:
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,12 +13,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0]
-        laravel: [8.*]
+        php: [8.0, 8.1]
+        laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 8.*
-            testbench: ^6.6
+          - laravel: 9.*
+            testbench: ^7.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ composer require stats4sd/laravel-file-util
 
 #### Pre-requisite:
 
-This package is developed for Laravel application with backpack package installed.
+The package has 3 main features, and you can use one or all of them in your project:
+
+- A trait `HasUploadFields`: this is based heavily on the trait shipped with Laravel Backpack, but customised slightly to our needs. 
+  - To use the trait, you need no other dependencies.
+- 2 Operation classes, to be used with Laravel Backpack.
+  - To use these operations, you should install the following extra dependencies:
+    - `composer require backpack/crud`
+    - `composer require maatwebsite/excel`
 
 ## 1. Exporting Data through a Laravel Backpack Crud panel
 

--- a/composer.json
+++ b/composer.json
@@ -16,19 +16,14 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.0|^8.1",
         "spatie/laravel-package-tools": "^1.4.3",
-        "illuminate/contracts": "^8.37",
-        "maatwebsite/excel": "^3.1",
-        "prologue/alerts": "^0.4.1",
         "intervention/image": "^2.5"
     },
     "require-dev": {
-        "nunomaduro/collision": "^5.3",
-        "orchestra/testbench": "^6.15",
-        "pestphp/pest": "^1.18",
-        "pestphp/pest-plugin-laravel": "^1.1",
-        "spatie/laravel-ray": "^1.23",
+        "nunomaduro/collision": "^6.1",
+        "orchestra/testbench": "^7.0",
+        "phpunit/phpunit": "^9.5.21",
         "vimeo/psalm": "^4.8"
     },
     "autoload": {

--- a/src/Models/Traits/HasUploadFields.php
+++ b/src/Models/Traits/HasUploadFields.php
@@ -135,7 +135,6 @@ trait HasUploadFields
 
     public function uploadImage($value, $attribute_name, $disk, $destination_path)
     {
-
         // if the image was erased
         if ($value == null) {
             // delete the image from disk

--- a/src/Models/Traits/HasUploadFields.php
+++ b/src/Models/Traits/HasUploadFields.php
@@ -94,7 +94,7 @@ trait HasUploadFields
     public function uploadMultipleFilesWithNames($value, $attribute_name, $disk, $destination_path)
     {
         if (! is_array($this->{$attribute_name})) {
-            $attribute_value = json_decode($this->{$attribute_name}, true) ?? [];
+            $attribute_value = json_decode((string)$this->{$attribute_name}, true) ?? [];
         } else {
             $attribute_value = $this->{$attribute_name};
         }

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -2,12 +2,10 @@
 
 namespace Stats4sd\FileUtil\Tests;
 
-use ExampleTestTwo;
 use PHPUnit\Framework\TestCase;
 
 class ExampleTest extends TestCase
 {
-
     /** @test */
     public function it_can_run_a_test(): void
     {

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,5 +1,16 @@
 <?php
 
-it('can test', function () {
-    expect(true)->toBeTrue();
-});
+namespace Stats4sd\FileUtil\Tests;
+
+use ExampleTestTwo;
+use PHPUnit\Framework\TestCase;
+
+class ExampleTest extends TestCase
+{
+
+    /** @test */
+    public function it_can_run_a_test(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,0 @@
-<?php
-
-use Stats4sd\FileUtil\Tests\TestCase;
-
-uses(TestCase::class)->in(__DIR__);


### PR DESCRIPTION
Adding support for Laravel 9. 

I also found that the existing requirements (Laravel Excel + Prologue Alerts) conflict with the Orchestra Testbench dev dependency. (Orchestra requires Illuminate/Support, and the  others require Laravel core, and composer cannot install both side-by-side - I think because Laravel Core contains Illuminate/Support?)

My solution is:
- Removed the 2 non-dev dependencies from here:
- Updated the Readme to explain that the HasUploadFields trait can be used without extra installations, but that the Import and Export Operations require Laravel Excel and Laravel Backpack 
- I didn't mention Prologue/Alerts because it is already a dependency of Backpack. 

